### PR TITLE
fix: make billing_id optional in entitlement check request

### DIFF
--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -1956,7 +1956,10 @@ message ListPlansResponse {
 message CheckFeatureEntitlementRequest {
   string org_id = 1;
   // ID of the billing account to update the subscription for
-  string billing_id = 2 [(validate.rules).string.uuid = true];
+  string billing_id = 2 [(validate.rules).string = {
+    ignore_empty: true,
+    uuid: true
+  }];
 
   // either provide billing_id of the org or API can infer the default
   // billing ID from either org_id or project_id, not both


### PR DESCRIPTION
The billing_id in entitlement check is now optional, since it can be inferred on the basis of org id or project id. This PR updates the message validation rules to ensure it is treated as optional.