### PR TITLE
feat(frontier):add pagination to ListOrganizations

### DIFF
--- a/raystack/frontier/v1beta1/admin.proto
+++ b/raystack/frontier/v1beta1/admin.proto
@@ -471,8 +471,8 @@ message ListAllOrganizationsRequest {
 
 message ListAllOrganizationsResponse {
   repeated Organization organizations = 1;
-  int32 total_pages = 2[
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Total number of pages in response"}
+  int32 count = 2[
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Total number of records present"}
       ];
 }
 

--- a/raystack/frontier/v1beta1/admin.proto
+++ b/raystack/frontier/v1beta1/admin.proto
@@ -458,7 +458,7 @@ message ListAllOrganizationsRequest {
       gte: 1,
       ignore_empty: true,
     },
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The maximum number of users to return per page. The default is 50."}
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The maximum number of organizations to return per page. The default is 50."}
   ];
   int32 page_num = 4 [
     (validate.rules).int32 = {
@@ -471,7 +471,9 @@ message ListAllOrganizationsRequest {
 
 message ListAllOrganizationsResponse {
   repeated Organization organizations = 1;
-  int32 total_pages = 2;
+  int32 total_pages = 2[
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "Total number of pages in response"}
+      ];
 }
 
 message ListProjectsRequest {

--- a/raystack/frontier/v1beta1/admin.proto
+++ b/raystack/frontier/v1beta1/admin.proto
@@ -453,10 +453,25 @@ message ListGroupsResponse {
 message ListAllOrganizationsRequest {
   string user_id = 1 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The user id to filter by."}];
   string state = 2 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The state to filter by. It can be enabled or disabled."}];
+  int32 page_size = 3 [
+    (validate.rules).int32 = {
+      gte: 1,
+      ignore_empty: true,
+    },
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The maximum number of users to return per page. The default is 50."}
+  ];
+  int32 page_num = 4 [
+    (validate.rules).int32 = {
+      gte: 1,
+      ignore_empty: true,
+    },
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {description: "The page number to return. The default is 1."}
+  ];
 }
 
 message ListAllOrganizationsResponse {
   repeated Organization organizations = 1;
+  int32 total_pages = 2;
 }
 
 message ListProjectsRequest {


### PR DESCRIPTION
Add new fields to `ListAllOrganizationsRequest` and `ListAllOrganizationsResponse` to enable pagination.

Fields added:
`page_size` ,`page_num` to `ListAllOrganizationsRequest` message
`total_pages` to `ListAllOrganizationsResponse` message