### PR TITLE
feat(frontier): add Proto for org KYC

### DIFF
--- a/raystack/frontier/v1beta1/admin.proto
+++ b/raystack/frontier/v1beta1/admin.proto
@@ -156,7 +156,7 @@ service AdminService {
 
   rpc SetOrganizationKyc(SetOrganizationKycRequest) returns (SetOrganizationKycResponse) {
     option (google.api.http) = {
-      put: "/v1beta1/organizations/{organization_id}/kyc",
+      put: "/v1beta1/admin/organizations/{organization_id}/kyc",
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {

--- a/raystack/frontier/v1beta1/admin.proto
+++ b/raystack/frontier/v1beta1/admin.proto
@@ -154,6 +154,18 @@ service AdminService {
     };
   }
 
+  rpc SetOrganizationKyc(SetOrganizationKycRequest) returns (SetOrganizationKycResponse) {
+    option (google.api.http) = {
+      put: "/v1beta1/organizations/{organization_id}/kyc",
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "OrganizationKyc";
+      summary: "Set KYC status of an organization";
+      description: "Set KYC status of an organization using ID or name";
+    };
+  }
+
   // Projects
   rpc ListProjects(ListProjectsRequest) returns (ListProjectsResponse) {
     option (google.api.http) = {get: "/v1beta1/admin/projects"};
@@ -815,3 +827,13 @@ message UpdateBillingAccountLimitsRequest {
 }
 
 message UpdateBillingAccountLimitsResponse {}
+
+message SetOrganizationKycRequest {
+  string organization_id = 1;
+  bool status = 2;
+  string link = 3;
+}
+
+message SetOrganizationKycResponse {
+  OrganizationKyc organization_kyc = 1;
+}

--- a/raystack/frontier/v1beta1/admin.proto
+++ b/raystack/frontier/v1beta1/admin.proto
@@ -156,13 +156,13 @@ service AdminService {
 
   rpc SetOrganizationKyc(SetOrganizationKycRequest) returns (SetOrganizationKycResponse) {
     option (google.api.http) = {
-      put: "/v1beta1/admin/organizations/{organization_id}/kyc",
+      put: "/v1beta1/admin/organizations/{org_id}/kyc",
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "OrganizationKyc";
-      summary: "Set KYC status of an organization";
-      description: "Set KYC status of an organization using ID or name";
+      summary: "Set KYC information of an organization";
+      description: "Set KYC information of an organization using ID or name";
     };
   }
 
@@ -829,7 +829,7 @@ message UpdateBillingAccountLimitsRequest {
 message UpdateBillingAccountLimitsResponse {}
 
 message SetOrganizationKycRequest {
-  string organization_id = 1;
+  string org_id = 1;
   bool status = 2;
   string link = 3;
 }

--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -701,7 +701,7 @@ service FrontierService {
   rpc SetOrganizationKycStatus(SetOrganizationKycStatusRequest) returns (SetOrganizationKycStatusResponse) {
     option (google.api.http) = {
       put: "/v1beta1/organizations/{organization_id}/kyc",
-      body: *
+      body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "OrganizationKyc";

--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -699,7 +699,7 @@ service FrontierService {
   }
 
   rpc GetOrganizationKyc(GetOrganizationKycRequest) returns (GetOrganizationKycResponse) {
-    option (google.api.http) = {get: "/v1beta1/organizations/{id}/kyc"};
+    option (google.api.http) = {get: "/v1beta1/organizations/{organization_id}/kyc"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "OrganizationKyc";
       summary: "Get KYC info of an organization";

--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -698,6 +698,24 @@ service FrontierService {
     };
   }
 
+  rpc SetOrganizationKycStatus(SetOrganizationKycStatusRequest) returns (SetOrganizationKycStatusResponse) {
+    option (google.api.http) = {put: "/v1beta1/organizations/{id}/kyc"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "OrganizationKyc";
+      summary: "Set KYC status of an organization";
+      description: "Set KYC status of an organization using ID or name";
+    };
+  }
+
+  rpc GetOrganizationKycStatus(GetOrganizationKycStatusRequest) returns (GetOrganizationKycStatusResponse) {
+    option (google.api.http) = {get: "/v1beta1/organizations/{id}/kyc"};
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      tags: "OrganizationKyc";
+      summary: "Get KYC status of an organization";
+      description: "Get KYC status of an organization using ID or name";
+    };
+  }
+
   // Deprecated: use ListServiceUsers instead
   rpc ListOrganizationServiceUsers(ListOrganizationServiceUsersRequest) returns (ListOrganizationServiceUsersResponse) {
     option (google.api.http) = {get: "/v1beta1/organizations/{id}/serviceusers"};
@@ -3336,6 +3354,24 @@ message DeleteOrganizationRequest {
 }
 
 message DeleteOrganizationResponse {}
+
+message SetOrganizationKycStatusRequest {
+  string organizationID = 1;
+  bool status = 2;
+  string link = 3;
+}
+
+message SetOrganizationKycStatusResponse {
+  OrganizationKyc organizationKyc = 1;
+}
+
+message GetOrganizationKycStatusRequest {
+  string id = 1;
+}
+
+message GetOrganizationKycStatusResponse {
+  OrganizationKyc organizationKyc = 1;
+}
 
 // Project
 

--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -3370,7 +3370,7 @@ message GetOrganizationKycStatusRequest {
 }
 
 message GetOrganizationKycStatusResponse {
-  OrganizationKyc organizationKyc = 1;
+  OrganizationKyc organization_kyc = 1;
 }
 
 // Project

--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -3356,7 +3356,7 @@ message DeleteOrganizationRequest {
 message DeleteOrganizationResponse {}
 
 message SetOrganizationKycStatusRequest {
-  string organizationID = 1;
+  string organization_id = 1;
   bool status = 2;
   string link = 3;
 }
@@ -3366,7 +3366,7 @@ message SetOrganizationKycStatusResponse {
 }
 
 message GetOrganizationKycStatusRequest {
-  string id = 1;
+  string organization_id = 1;
 }
 
 message GetOrganizationKycStatusResponse {

--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -699,7 +699,7 @@ service FrontierService {
   }
 
   rpc GetOrganizationKyc(GetOrganizationKycRequest) returns (GetOrganizationKycResponse) {
-    option (google.api.http) = {get: "/v1beta1/organizations/{organization_id}/kyc"};
+    option (google.api.http) = {get: "/v1beta1/organizations/{org_id}/kyc"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "OrganizationKyc";
       summary: "Get KYC info of an organization";
@@ -3347,7 +3347,7 @@ message DeleteOrganizationRequest {
 message DeleteOrganizationResponse {}
 
 message GetOrganizationKycRequest {
-  string organization_id = 1;
+  string org_id = 1;
 }
 
 message GetOrganizationKycResponse {

--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -698,24 +698,12 @@ service FrontierService {
     };
   }
 
-  rpc SetOrganizationKycStatus(SetOrganizationKycStatusRequest) returns (SetOrganizationKycStatusResponse) {
-    option (google.api.http) = {
-      put: "/v1beta1/organizations/{organization_id}/kyc",
-      body: "*"
-    };
+  rpc GetOrganizationKyc(GetOrganizationKycRequest) returns (GetOrganizationKycResponse) {
+    option (google.api.http) = {get: "/v1beta1/organizations/{id}/kyc"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "OrganizationKyc";
-      summary: "Set KYC status of an organization";
-      description: "Set KYC status of an organization using ID or name";
-    };
-  }
-
-  rpc GetOrganizationKycStatus(GetOrganizationKycStatusRequest) returns (GetOrganizationKycStatusResponse) {
-    option (google.api.http) = {get: "/v1beta1/organizations/{organization_id}/kyc"};
-    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      tags: "OrganizationKyc";
-      summary: "Get KYC status of an organization";
-      description: "Get KYC status of an organization using ID or name";
+      summary: "Get KYC info of an organization";
+      description: "Get KYC info of an organization using ID or name";
     };
   }
 
@@ -3358,21 +3346,11 @@ message DeleteOrganizationRequest {
 
 message DeleteOrganizationResponse {}
 
-message SetOrganizationKycStatusRequest {
-  string organization_id = 1;
-  bool status = 2;
-  string link = 3;
-}
-
-message SetOrganizationKycStatusResponse {
-  OrganizationKyc organization_kyc = 1;
-}
-
-message GetOrganizationKycStatusRequest {
+message GetOrganizationKycRequest {
   string organization_id = 1;
 }
 
-message GetOrganizationKycStatusResponse {
+message GetOrganizationKycResponse {
   OrganizationKyc organization_kyc = 1;
 }
 

--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -3362,7 +3362,7 @@ message SetOrganizationKycStatusRequest {
 }
 
 message SetOrganizationKycStatusResponse {
-  OrganizationKyc organizationKyc = 1;
+  OrganizationKyc organization_kyc = 1;
 }
 
 message GetOrganizationKycStatusRequest {

--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -699,7 +699,7 @@ service FrontierService {
   }
 
   rpc SetOrganizationKycStatus(SetOrganizationKycStatusRequest) returns (SetOrganizationKycStatusResponse) {
-    option (google.api.http) = {put: "/v1beta1/organizations/{id}/kyc"};
+    option (google.api.http) = {put: "/v1beta1/organizations/{organization_id}/kyc"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "OrganizationKyc";
       summary: "Set KYC status of an organization";
@@ -708,7 +708,7 @@ service FrontierService {
   }
 
   rpc GetOrganizationKycStatus(GetOrganizationKycStatusRequest) returns (GetOrganizationKycStatusResponse) {
-    option (google.api.http) = {get: "/v1beta1/organizations/{id}/kyc"};
+    option (google.api.http) = {get: "/v1beta1/organizations/{organization_id}/kyc"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "OrganizationKyc";
       summary: "Get KYC status of an organization";

--- a/raystack/frontier/v1beta1/frontier.proto
+++ b/raystack/frontier/v1beta1/frontier.proto
@@ -699,7 +699,10 @@ service FrontierService {
   }
 
   rpc SetOrganizationKycStatus(SetOrganizationKycStatusRequest) returns (SetOrganizationKycStatusResponse) {
-    option (google.api.http) = {put: "/v1beta1/organizations/{organization_id}/kyc"};
+    option (google.api.http) = {
+      put: "/v1beta1/organizations/{organization_id}/kyc",
+      body: *
+    };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "OrganizationKyc";
       summary: "Set KYC status of an organization";

--- a/raystack/frontier/v1beta1/models.proto
+++ b/raystack/frontier/v1beta1/models.proto
@@ -151,7 +151,7 @@ message Organization {
 }
 
 message OrganizationKyc {
-  string organization_id = 1;
+  string org_id = 1;
   bool status = 2;
   string link = 3;
   google.protobuf.Timestamp created_at = 5 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {

--- a/raystack/frontier/v1beta1/models.proto
+++ b/raystack/frontier/v1beta1/models.proto
@@ -150,6 +150,20 @@ message Organization {
   ];
 }
 
+message OrganizationKyc {
+  string id = 1;
+  bool status = 2;
+  string link = 3;
+  google.protobuf.Timestamp created_at = 5 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+    description: "The time the organization kyc was created.",
+    example: "\"2023-06-07T05:39:56.961Z\""
+  }];
+  google.protobuf.Timestamp updated_at = 6 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+    description: "The time the organization kyc was last updated.",
+    example: "\"2023-06-07T05:39:56.961Z\""
+  }];
+}
+
 message Project {
   string id = 1;
   string name = 2 [(validate.rules).string = {

--- a/raystack/frontier/v1beta1/models.proto
+++ b/raystack/frontier/v1beta1/models.proto
@@ -151,7 +151,7 @@ message Organization {
 }
 
 message OrganizationKyc {
-  string id = 1;
+  string organization_id = 1;
   bool status = 2;
   string link = 3;
   google.protobuf.Timestamp created_at = 5 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {


### PR DESCRIPTION
# Description

Add proto messages and RPC contract for Org KYC management. 

The Org KYC consists of 3 main fields: 
1. OrgID
2. KYC status (True/False)
3. KYC Doc Link

The GRPC Gateway should expose these endpoints to allow Org KYC management :
1. `get: "/v1beta1/organizations/{org_id}/kyc"`
2. `put: "/v1beta1/admin/organizations/{org_id}/kyc"`