### PR TITLE
chore: remove old ts exports

### DIFF
--- a/js/buf.gen.yaml
+++ b/js/buf.gen.yaml
@@ -5,8 +5,6 @@ plugins:
       - target=ts
       - import_extension=none
     out: js/dist
-  - name: ts
-    out: js/dist
   - name: connect-query
     opt:
       - target=ts


### PR DESCRIPTION
This PR exports the entity structs from the `_pb.ts` file.
Currently in the build step, we generate two entity definition files. One is a plain TS struct, and the other is a Message Struct.
We export the plain TS struct in the services index.ts file. Using this plain TS struct in consumer code results in a TS error because the type used in the request and response in the Connect query is the Entity Message struct.

eg If we import the following code from proton
```ts
import type { Organization, GetOrganizationResponse } from '@raystack/proton/frontier
```
The `GetOrganizationResponse.organization` will not satisfy the type of `Organization`

When we build, we create `frontier.ts` and `frontier_pb.ts` files. Both files will have `Organization` structs.

We can't export both, as there will be conflicts because both structs will have the same name.
We will remove the old structs and use only the connect v2 version.
The same has been recommended in the [migration guide](https://github.com/connectrpc/connect-es/blob/main/MIGRATING.md) as well. 

